### PR TITLE
Simplify consent step

### DIFF
--- a/prospector/apis/crm/crm.py
+++ b/prospector/apis/crm/crm.py
@@ -562,6 +562,7 @@ def map_crm(answers: models.Answers) -> dict:
         "cr51a_children": answers.children,
         "cr51a_childreneligibleforfreeschoolmeals": answers.free_school_meals_eligibility,
         "cr51a_counciltaxreductionentitlement": answers.council_tax_reduction,
+        # Keep future schemes consent for backwards compatibility with Dynamics
         "cr51a_consented_callback": answers.consented_callback,
         "cr51a_consented_future_schemes": answers.consented_future_schemes,
         "cr51a_heatedrooms": answers.heated_rooms,

--- a/prospector/apps/questionnaire/forms.py
+++ b/prospector/apps/questionnaire/forms.py
@@ -291,20 +291,17 @@ class PropertyAddress(AnswerFormMixin, forms.ModelForm):
 
 class Consents(AnswerFormMixin, forms.ModelForm):
     consented_callback = forms.BooleanField(
-        required=False, label="To call or email you to offer advice and help."
-    )
-    consented_future_schemes = forms.BooleanField(
         required=False,
         label=(
-            "To contact you in the future when we think there are grants or "
-            "programmes relevant for you."
+            "To call or email you now or in the future with advice or details "
+            "of relevant grants."
         ),
     )
 
     class Meta:
         model = models.Answers
-        optional_fields = ["consented_callback", "consented_future_schemes"]
-        fields = ["consented_callback", "consented_future_schemes"]
+        optional_fields = ["consented_callback"]
+        fields = ["consented_callback"]
 
     def clean(self):
         """If fields weren't submitted, make them False."""
@@ -312,8 +309,9 @@ class Consents(AnswerFormMixin, forms.ModelForm):
         data = super().clean()
         if data.get("consented_callback") is None:
             data["consented_callback"] = False
-        if data.get("consented_future_schemes") is None:
-            data["consented_future_schemes"] = False
+
+        # Mirror the value for future schemes consent to maintain existing data
+        data["consented_future_schemes"] = data["consented_callback"]
 
         return data
 

--- a/prospector/templates/questionnaire/consents.html
+++ b/prospector/templates/questionnaire/consents.html
@@ -7,13 +7,12 @@
 {% block question_text %}
     <h2 class="question-heading">
         {% include "./includes/icon_agree.html" %}
-        Your consent in how your data is used
+        Your consent to be contacted
     </h2>
-    <p>Please tell us which of the following purposes you are happy for us to
-        store and use your data for:</p>
+    <p>Please confirm that you're happy for us to get in touch with you with
+        advice and information on relevant grants.</p>
 {% endblock question_text %}
 
 {% block form_content %}
     {{ form.consented_callback|as_crispy_field }}
-    {{ form.consented_future_schemes|as_crispy_field }}
 {% endblock form_content %}


### PR DESCRIPTION
## Summary
- streamline consent question for contacting respondents
- leave CRM payload unchanged but document future schemes mapping

## Testing
- `make test` *(fails: no rule)*
- `pre-commit run --files prospector/apis/crm/crm.py prospector/apps/questionnaire/forms.py prospector/templates/questionnaire/consents.html` *(fails: `.pre-commit-config.yaml` not found)*
- `pytest -q` *(fails: ModuleNotFoundError: django)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: webpack not found)*
- `make -C docs html` *(fails: no rule)*

------
https://chatgpt.com/codex/tasks/task_b_6888abdd18c083218aafe4d7da60e6dc