### PR TITLE
Improve docs and agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # Agent Guidelines
 
-This project contains a Python backend and a small JavaScript front end.
+This project contains a Django backend and a small JavaScript front end.
 
 ## Testing and formatting
-- Run `make test` before committing to ensure all Python tests and lint checks pass.
-- Run `pre-commit run --files <changed files>` or `pre-commit run --all` if pre-commit hooks are installed.
+- Install Python requirements with `pip install -r requirements.txt`.
+- Run `pytest` before committing to ensure all backend tests and lint checks pass.
+- Run `pre-commit run --files <changed files>` or `pre-commit run --all` if hooks are installed.
 - For front end changes you can run `npm test` to execute the JavaScript tests and `npm run build` to compile assets.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Retrofit Eligibility Web Tool
+
+This repository contains a Django application used to assess property eligibility for retrofit measures. It exposes a REST API and a small JavaScript front end served via webpack.
+
+## Getting Started
+
+1. Copy `example.env` to `.env` and adjust any environment variables.
+2. Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Install JavaScript dependencies:
+
+```bash
+npm install
+```
+
+4. Apply database migrations and start the development server:
+
+```bash
+./manage.py migrate
+./manage.py runserver
+```
+
+See `docs/developing/getting-started.rst` for full setup instructions.
+
+## Running Tests
+
+Backend tests use `pytest` with settings from `config.settings.test`:
+
+```bash
+pytest
+```
+
+Front end tests can be run with:
+
+```bash
+npm test
+```
+
+## Building Documentation
+
+Documentation lives in the `docs/` directory. Build the HTML pages with:
+
+```bash
+make -C docs html
+```
+
+


### PR DESCRIPTION
## Summary
- add overview and setup steps to README
- update agent guidelines with pytest-based workflow

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: `REDIS_HOST` not set)*
- `npm test` *(fails: `jest` not found)*
- `npm run build` *(fails: `webpack` not found)*
- `pre-commit run --files README.md AGENTS.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6888b1e0426483218c61406edc8649b7