### PR TITLE
Fix WHLG eligibility when income missing

### DIFF
--- a/prospector/apps/questionnaire/models.py
+++ b/prospector/apps/questionnaire/models.py
@@ -801,6 +801,13 @@ class Answers(models.Model):
     @property
     def is_whlg_eligible(self) -> Optional[bool]:
         """Check eligibility for the Warm Homes: Local Grant scheme."""
+        if (
+            self.sap_band is None
+            or self.tenure is None
+            or self.household_income is None
+        ):
+            return None
+
         return (
             self.sap_band in SAP_BANDS
             and self.tenure


### PR DESCRIPTION
## Summary
- avoid TypeError in `Answers.is_whlg_eligible`

## Testing
- `pre-commit run --files prospector/apps/questionnaire/models.py` *(fails: `.pre-commit-config.yaml is not a file`)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_b_6888eb42acf4832196a38359f3da6d35