### PR TITLE
Fix progress bar template typo

### DIFF
--- a/prospector/templates/questionnaire/base_question.html
+++ b/prospector/templates/questionnaire/base_question.html
@@ -7,7 +7,7 @@
 
     <div class="progress">
         <label for="progress">progress</label>
-        <progress id="progress" min="0" max="100" value="{{ percent_complete }}">(( percent_complete }}%</progress>
+        <progress id="progress" min="0" max="100" value="{{ percent_complete }}">{{ percent_complete }}%</progress>
     </div>
 
     {% if prev_url %}


### PR DESCRIPTION
## Summary
- fix progress bar markup in questionnaire base template

## Testing
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_b_6889e91567a88321806461dbc4f44819