### PR TITLE
Ensure unique identifiers for prefilled addresses

### DIFF
--- a/prospector/apis/data8.py
+++ b/prospector/apis/data8.py
@@ -27,29 +27,39 @@ class AddressData:
     id: str  # Fallback identifier
 
 
+def _extract_additional_value(raw: dict, name: str) -> str:
+    """Get a value from RawAddress.AdditionalData by Name."""
+    for kv in (raw or {}).get("AdditionalData", []) or []:
+        if kv.get("Name") == name and kv.get("Value"):
+            return str(kv["Value"])
+    return ""
+
+
 def _process_results(results: list) -> List[AddressData]:
     out: List[AddressData] = []
 
     for i, row in enumerate(results or []):
         addr = row.get("Address", {}) or {}
         lines = addr.get("Lines", []) or []
-        district = row.get("District", "") or ""  # present when IncludeAdminArea=True
-        uprn = str(row.get("UPRN") or "")
-        fallback_id = f"addr-{i}"
+        raw = row.get("RawAddress", {}) or {}
+        loc = raw.get("Location", {}) or {}
 
         def _get(j: int) -> str:
             return lines[j] if j < len(lines) else ""
+
+        # UPRN is provided in RawAddress.AdditionalData as {"Name": "UPRN", "Value": "..."}
+        uprn = _extract_additional_value(raw, "UPRN") or str(row.get("UPRN") or raw.get("UPRN") or "")
 
         out.append(
             AddressData(
                 line_1=_get(0),
                 line_2=_get(1),
                 line_3=_get(2),
-                post_town=_get(4),   # Data8 commonly places town at index 4
-                district=district,
-                postcode=_get(6),    # and postcode at index 6
+                post_town=_get(4),   # town commonly at index 4
+                district=str(loc.get("District") or ""),  # in your payload, District lives under RawAddress.Location
+                postcode=_get(6),    # postcode commonly at index 6
                 uprn=uprn,
-                id=fallback_id,
+                id=f"addr-{i}",
             )
         )
 
@@ -115,8 +125,14 @@ def get_for_postcode(raw_postcode: str) -> Optional[List[AddressData]]:
         return []
 
     try:
-        return _process_results(data.get("Results", []))
+        addresses = _process_results(data.get("Results", []))
     except Exception as e:
         # Guard against unexpected shape changes
         logger.error(f"Data8 response parse error for {postcode}: {e}")
         return []
+
+    # Helpful signal if the API shape changes or licence/options don’t return UPRN
+    if params["options"].get("IncludeUPRN") and addresses and all(not a.uprn for a in addresses):
+        logger.warning("Data8: IncludeUPRN=True but no UPRN values found in results for %s", postcode)
+
+    return addresses

--- a/prospector/apis/data8.py
+++ b/prospector/apis/data8.py
@@ -24,19 +24,21 @@ class AddressData:
     district: str
     postcode: str
     uprn: str  # UPRN only
+    id: str  # Fallback identifier
 
 
 def _process_results(results: list) -> List[AddressData]:
     out: List[AddressData] = []
 
-    for row in results or []:
+    for i, row in enumerate(results or []):
         addr = row.get("Address", {}) or {}
         lines = addr.get("Lines", []) or []
         district = row.get("District", "") or ""  # present when IncludeAdminArea=True
         uprn = str(row.get("UPRN") or "")
+        fallback_id = f"addr-{i}"
 
-        def _get(i: int) -> str:
-            return lines[i] if i < len(lines) else ""
+        def _get(j: int) -> str:
+            return lines[j] if j < len(lines) else ""
 
         out.append(
             AddressData(
@@ -47,6 +49,7 @@ def _process_results(results: list) -> List[AddressData]:
                 district=district,
                 postcode=_get(6),    # and postcode at index 6
                 uprn=uprn,
+                id=fallback_id,
             )
         )
 
@@ -79,7 +82,7 @@ def get_for_postcode(raw_postcode: str) -> Optional[List[AddressData]]:
         "postcode": postcode,
         "options": {
             "ApplicationName": "Prospector",
-            # Request **only** UPRN (do not request UDPRN alongside it)
+            # Request only UPRN
             "IncludeUPRN": True,
             "IncludeAdminArea": True,
             # Normalisation helpers (exact casing matters)

--- a/prospector/apis/fake_postcodes.py
+++ b/prospector/apis/fake_postcodes.py
@@ -12,6 +12,7 @@ class AddressData:
     district: str
     postcode: str
     uprn: str
+    id: str
 
 
 def get_for_postcode(raw_postcode: str) -> Optional[list]:
@@ -24,6 +25,7 @@ def get_for_postcode(raw_postcode: str) -> Optional[list]:
             "",
             "PL1 2AB",
             "100000000000",
+            "addr-0",
         )
     ]
 

--- a/prospector/apps/questionnaire/forms.py
+++ b/prospector/apps/questionnaire/forms.py
@@ -135,17 +135,17 @@ class RespondentAddress(AnswerFormMixin, forms.ModelForm):
 
         self.prefilled_addresses = prefilled_addresses
 
-        uprn_choices = [
-            (uprn, f"{house.line_1}, {house.line_2}".strip(", "))
-            for uprn, house in prefilled_addresses.items()
+        address_choices = [
+            (key, f"{house.line_1}, {house.line_2}".strip(", "))
+            for key, house in prefilled_addresses.items()
         ]
-        uprn_choices.append((None, "Address not in the list"))
-        uprn_choices.insert(0, (None, "Click here to choose the address"))
+        address_choices.append((None, "Address not in the list"))
+        address_choices.insert(0, (None, "Click here to choose the address"))
         self.fields["respondent_udprn"] = forms.ChoiceField(
-            required=False, choices=uprn_choices
+            required=False, choices=address_choices
         )
 
-        self.initial["respondent_udprn"] = uprn_choices[0][0]
+        self.initial["respondent_udprn"] = address_choices[0][0]
 
     class Meta:
         model = models.Answers
@@ -251,8 +251,8 @@ class PropertyAddress(AnswerFormMixin, forms.ModelForm):
         self.prefilled_addresses = prefilled_addresses
 
         address_choices = [
-            (uprn, f"{house.line_1}, {house.line_2}".strip(", "))
-            for uprn, house in prefilled_addresses.items()
+            (key, f"{house.line_1}, {house.line_2}".strip(", "))
+            for key, house in prefilled_addresses.items()
         ]
         address_choices.append((None, "Address not in the list"))
         address_choices.insert(0, (None, "Click here to choose the address"))

--- a/prospector/apps/questionnaire/selectors.py
+++ b/prospector/apps/questionnaire/selectors.py
@@ -85,6 +85,7 @@ def _process_cached_results(results):
             row["district"],
             row["postcode"],
             row["uprn"],
+            row["id"],
         )
         for row in results
     ]

--- a/prospector/apps/questionnaire/tests/test_selectors.py
+++ b/prospector/apps/questionnaire/tests/test_selectors.py
@@ -16,6 +16,7 @@ DUMMY_RESULTS = [
         "Manchester District",
         "M4 7HR",
         "524181705241",
+        "addr-0",
     )
 ]
 

--- a/prospector/apps/questionnaire/views/trail.py
+++ b/prospector/apps/questionnaire/views/trail.py
@@ -172,8 +172,10 @@ class RespondentAddress(abstract_views.Question):
 
         try:
             self.prefilled_addresses = {
-                address.uprn: address
-                for address in get_for_postcode(self.answers.respondent_postcode)
+                (address.uprn or address.id or f"addr-{i}"): address
+                for i, address in enumerate(
+                    get_for_postcode(self.answers.respondent_postcode)
+                )
             }
         except Exception:
             pass
@@ -222,10 +224,10 @@ class RespondentAddress(abstract_views.Question):
         initial address field values so it provides the user-submitted values,
         which may have been edited from the API-supplied values. Possible
         solutions are:
-        - Test to see whether the UDPRN has changed but address_1 has not
+        - Test to see whether the address identifier has changed but address_1 has not
         - Split this into an additional step:
             1. postcode -> 2. select property/not in list -> 3. confirm address
-          (would still have to check for a change in UDPRN before overwriting address?)
+          (would still have to check for a change in identifier before overwriting address?)
         - hide address selector if address fields are populated
         """
 
@@ -281,8 +283,10 @@ class PropertyAddress(abstract_views.Question):
 
         try:
             self.prefilled_addresses = {
-                address.uprn: address
-                for address in get_for_postcode(self.answers.property_postcode)
+                (address.uprn or address.id or f"addr-{i}"): address
+                for i, address in enumerate(
+                    get_for_postcode(self.answers.property_postcode)
+                )
             }
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- generate a fallback ID for each Data8 address instead of using UDPRN
- update postcode caching and tests to use the new address ID
- build prefilled address lookups using `address.uprn` or generated IDs

## Testing
- `DJANGO_SETTINGS_MODULE=config.settings.test pytest` *(fails: ImportError: No module named 'ssm_parameter_store')*

------
https://chatgpt.com/codex/tasks/task_b_68aef43c73ec8321a20b3eb6c7891c5a