### PR TITLE
Stop populating UDPRN fields

### DIFF
--- a/prospector/apis/crm/crm.py
+++ b/prospector/apis/crm/crm.py
@@ -219,7 +219,8 @@ def map_crm(answers: models.Answers) -> dict:
         "pcc_towncity": "PLYMOUTH",
         "pcc_county": None,  # Leave blank
         "pcc_postcode": answers.property_postcode,
-        "pcc_udprn": answers.property_udprn,
+        # UDPRN values are not available; leave blank in CRM payload
+        "pcc_udprn": None,
         "pcc_likelihoodofprivatelyrented": (
             option_value_mapping(
                 "pcc_likelihoodofprivatelyrented",
@@ -446,7 +447,8 @@ def map_crm(answers: models.Answers) -> dict:
         "pcc_address1city": answers.respondent_address_3,
         "pcc_address1county": None,
         "pcc_address1zippostalcode": answers.respondent_postcode,
-        "pcc_udprncontact": answers.respondent_udprn,
+        # UDPRN values are not available; leave blank in CRM payload
+        "pcc_udprncontact": None,
         # Occupier
         "pcc_occupiedfrom": None,
         "pcc_occupiedto": None,

--- a/prospector/apis/crm/tests/test_crm.py
+++ b/prospector/apis/crm/tests/test_crm.py
@@ -330,6 +330,20 @@ def test_map_crm(answers):
 
 
 @pytest.mark.django_db
+def test_map_crm_does_not_populate_udprn(answers):
+    """Ensure UDPRN fields are always left empty in CRM payload."""
+    dummy_answers = answers(
+        property_udprn="1234567890",
+        respondent_udprn="0987654321",
+        uprn="100040423808",
+    )
+    crm_data = crm.map_crm(dummy_answers)
+    assert crm_data["pcc_udprn"] is None
+    assert crm_data["pcc_udprncontact"] is None
+    assert crm_data["cr51a_uprn"] == "100040423808"
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "property_ownership,expected",
     [

--- a/prospector/apps/questionnaire/views/trail.py
+++ b/prospector/apps/questionnaire/views/trail.py
@@ -213,6 +213,8 @@ class RespondentAddress(abstract_views.Question):
                 self.answers.respondent_address_1 = selected_address.line_1
                 self.answers.respondent_address_2 = selected_address.line_2
                 self.answers.respondent_address_3 = selected_address.post_town
+        # Clear stored UDPRN as Data8 only provides UPRN
+        self.answers.respondent_udprn = ""
         """ # TODO (maybe)
         There is an edge case where a user with JS disabled selects an
         address from the API-supplied list (which populates the address fields
@@ -317,7 +319,9 @@ class PropertyAddress(abstract_views.Question):
                 self.answers.property_address_1 = selected_address.line_1
                 self.answers.property_address_2 = selected_address.line_2
                 self.answers.property_address_3 = selected_address.post_town
-            self.answers.property_udprn = selected_address.uprn
+            # UDPRN values are not available from Data8; ensure the field remains blank
+            self.answers.property_udprn = ""
+            # UPRN is still stored separately
             self.answers.uprn = selected_address.uprn
 
         if self.answers.property_address_1:


### PR DESCRIPTION
## Summary
- clear UDPRN fields and only store UPRN
- prevent CRM payload from including UDPRN values
- add regression test ensuring UDPRN remains empty

## Testing
- `REDIS_HOST=localhost DJANGO_SETTINGS_MODULE=config.settings.test .venv/bin/pytest prospector/apis/crm/tests/test_crm.py::test_map_crm_does_not_populate_udprn -q` *(fails: settings.DATABASES is improperly configured)*

------
https://chatgpt.com/codex/tasks/task_b_68af1569264883219671bbaadc60f8b9