### PR TITLE
Normalise name capitalisation before sending to the CRM

### DIFF
--- a/prospector/apis/crm/crm.py
+++ b/prospector/apis/crm/crm.py
@@ -11,6 +11,7 @@ from requests_oauthlib import OAuth2Session
 
 from prospector.apps.questionnaire import enums
 from prospector.apps.questionnaire import models
+from prospector.dataformats import names
 
 logger = logging.getLogger(__name__)
 
@@ -438,8 +439,8 @@ def map_crm(answers: models.Answers) -> dict:
         "pcc_propertyeligibilityscore": None,  # Leave blank after Phase 3 changes
         # Contact
         "pcc_salutation": None,
-        "pcc_firstname": answers.occupant_details["first_name"],
-        "pcc_lastname": answers.occupant_details["last_name"],
+        "pcc_firstname": names.normalise(answers.occupant_details["first_name"]),
+        "pcc_lastname": names.normalise(answers.occupant_details["last_name"]),
         "pcc_homephone": answers.occupant_details["phone"],
         "pcc_mobile": answers.occupant_details["mobile"],
         "pcc_email": answers.occupant_details["email"],
@@ -464,8 +465,12 @@ def map_crm(answers: models.Answers) -> dict:
         "pcc_lladdress1county": None,
         "pcc_lladdress1zippostalcode": answers.landlord_details["postcode"],
         "pcc_llmainphone": answers.landlord_details["phone"],
-        "cr51a_llcontactfirstname": answers.landlord_details["first_name"],
-        "cr51a_llcontactlastname": answers.landlord_details["last_name"],
+        "cr51a_llcontactfirstname": names.normalise(
+            answers.landlord_details["first_name"]
+        ),
+        "cr51a_llcontactlastname": names.normalise(
+            answers.landlord_details["last_name"]
+        ),
         "cr51a_llcontactemail": answers.landlord_details["email"],
         "cr51a_llcontactmobile": answers.landlord_details["mobile"],
         "cr51a_llcontacthomephone": answers.landlord_details["phone"],
@@ -604,8 +609,8 @@ def map_crm(answers: models.Answers) -> dict:
             )
         ),
         "cr51a_respondentemailadress": answers.email,
-        "cr51a_respondentfirstname": answers.first_name,
-        "cr51a_respondentlastname": answers.last_name,
+        "cr51a_respondentfirstname": names.normalise(answers.first_name),
+        "cr51a_respondentlastname": names.normalise(answers.last_name),
         "cr51a_respondentmobile": answers.contact_mobile,
         "cr51a_respondentphonenumber": answers.contact_phone,
         "cr51a_respondentrelationshiptooccupier": answers.respondent_role_other,

--- a/prospector/dataformats/names.py
+++ b/prospector/dataformats/names.py
@@ -1,0 +1,89 @@
+"""
+Tidy up the capitalisation of personal names.
+
+People type their names however they like -- "jane smith", "JANE SMITH" -- and
+whatever we send is what the CRM displays.  `normalise()` fixes the obvious
+cases and deliberately leaves anything else alone.
+"""
+from typing import Optional
+
+# Particles that stay lower case when they appear part-way through a name,
+# as in "van der Berg" or "de la Cruz".
+_PARTICLES = {
+    "af",
+    "al",
+    "bin",
+    "binte",
+    "da",
+    "de",
+    "del",
+    "della",
+    "den",
+    "der",
+    "des",
+    "di",
+    "do",
+    "dos",
+    "du",
+    "el",
+    "ibn",
+    "la",
+    "le",
+    "ten",
+    "ter",
+    "van",
+    "von",
+    "y",
+    "zu",
+}
+
+
+def _capitalise(part: str) -> str:
+    # Unlike str.capitalize() this leaves the rest of the part as it is.
+    if not part:
+        return part
+
+    return part[0].upper() + part[1:]
+
+
+def _capitalise_word(word: str) -> str:
+    # Both halves of a double-barrelled name: "smith-jones" -> "Smith-Jones".
+    word = "-".join(_capitalise(part) for part in word.split("-"))
+
+    # "o'brien" -> "O'Brien", but not "smith's" -- only a very short prefix is
+    # likely to be a name particle.
+    prefix, apostrophe, rest = word.partition("'")
+    if apostrophe and len(prefix) <= 2:
+        word = prefix + "'" + _capitalise(rest)
+
+    # "mcdonald" -> "McDonald".  Mac is left alone; there are too many names it
+    # would get wrong ("Macey", "Mackie", "Machin").
+    if len(word) > 4 and word.startswith("Mc"):
+        word = "Mc" + _capitalise(word[2:])
+
+    return word
+
+
+def normalise(name: Optional[str]) -> Optional[str]:
+    """
+    Return `name` with sensible capitalisation.
+
+    Whitespace is always tidied up.  The capitalisation is only changed if the
+    name arrived entirely in upper or lower case -- if there's a mix then the
+    user has capitalised it deliberately ("McDonald", "van Dijk", "ffrench")
+    and we would do more harm than good by second-guessing them.
+
+    Empty values and None are passed straight through.
+    """
+    if not name:
+        return name
+
+    name = " ".join(name.split())
+
+    if not (name.isupper() or name.islower()):
+        return name
+
+    return " ".join(
+        word if index and word in _PARTICLES else _capitalise_word(word)
+        for index, word in enumerate(name.lower().split(" "))
+    )

--- a/prospector/dataformats/tests/test_names.py
+++ b/prospector/dataformats/tests/test_names.py
@@ -1,0 +1,82 @@
+import pytest
+
+from prospector.dataformats.names import normalise
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("jane smith", "Jane Smith"),
+        ("JANE SMITH", "Jane Smith"),
+        ("jane", "Jane"),
+        ("JANE", "Jane"),
+    ],
+)
+def test_single_case_names_are_recased(name, expected):
+    assert normalise(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Jane Smith",
+        "Jane McDonald",
+        "Jane van Dijk",
+        "Jane ffrench",
+        "Jane MacLeod",
+    ],
+)
+def test_mixed_case_names_are_left_alone(name):
+    assert normalise(name) == name
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("smith-jones", "Smith-Jones"),
+        ("SMITH-JONES", "Smith-Jones"),
+        ("o'brien", "O'Brien"),
+        ("d'arcy", "D'Arcy"),
+        ("mcdonald", "McDonald"),
+        ("mccoy", "McCoy"),
+        ("mcgee", "McGee"),
+    ],
+)
+def test_compound_surnames(name, expected):
+    assert normalise(name) == expected
+
+
+@pytest.mark.parametrize("name", ["macey", "mackie", "machin"])
+def test_mac_is_not_treated_as_a_prefix(name):
+    # Guessing here does more harm than good, so we just capitalise.
+    assert normalise(name) == name.capitalize()
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("piet van der berg", "Piet van der Berg"),
+        ("MARIA DE LA CRUZ", "Maria de la Cruz"),
+        # A particle at the start of the field still gets capitalised.
+        ("van der berg", "Van der Berg"),
+    ],
+)
+def test_particles_stay_lower_case_mid_name(name, expected):
+    assert normalise(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("  jane   smith  ", "Jane Smith"),
+        ("Jane   Smith", "Jane Smith"),
+        ("jane\tsmith", "Jane Smith"),
+    ],
+)
+def test_whitespace_is_tidied(name, expected):
+    assert normalise(name) == expected
+
+
+@pytest.mark.parametrize("name", [None, "", "   "])
+def test_empty_values_pass_through(name):
+    assert normalise(name) in (name, "")


### PR DESCRIPTION
Names are typed by respondents and go to the CRM exactly as entered, so "jane smith" and "JANE SMITH" both end up on the record.

Adds prospector/dataformats/names.py, alongside the existing phone_numbers and postcodes formatters, and applies it to the six name fields in map_crm() (respondent, occupant and landlord contact). Doing it at the mapping stage means every submission route is covered and nothing the user typed is overwritten in our own database.

The capitalisation is only changed when the name arrives entirely in upper or lower case. A name with mixed case was capitalised deliberately -- "McDonald", "van Dijk", "ffrench" -- and re-casing it would do more harm than good. Whitespace is always tidied.